### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -13,7 +13,7 @@
     },
     "repo-type"    : "git",
     "source-url"   : "https://github.com/lizmat/PackUnpack.git",
-    "license"      : "http://www.perlfoundation.org/artistic_license_2_0",
+    "license"      : "Artistic-2.0",
     "support"      : {
       "irc"          : "irc://irc.freenode.org/#perl6"
     }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license